### PR TITLE
allow adding repository using CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,20 @@ Where CHARTS_CONFIG is the location of the YAML file
 containing the Kubernetes Charts configuration.
 
 Arguments:
-  CHARTS_CONFIG           Charts configuration file
+  CHARTS_CONFIG                    Charts configuration file
 
 Options:
-  -h, --help              Show this screen
-  --version               Show version
-  -n NS, --namespace=NS   Set the .Release.Namespace chart variable, used by
-                          Charts during compilation
-  -a NAME, --name=NAME    Set the .Release.Name chart variable, used by charts
-                          during compilation
-  -o, --output PATH       Write output to a file, instead of STDOUT
-  --example-config        Print an example charts.yaml, including extended
-                          documentation on the tunables
+  -h, --help                       Show this screen
+  --version                        Show version
+  -n NS, --namespace=NS            Set the .Release.Namespace chart variable,
+                                   used by charts during compilation
+  -a NAME, --name=NAME             Set the .Release.Name chart variable, used by
+                                   charts during compilation
+  -o PATH, --output=PATH           Write output to a file, instead of STDOUT
+  -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
+                                   to the index before compiling charts config
+  --example-config                 Print an example charts.yaml, including
+                                   extended documentation on the tunables
 ```
 
 ## Charts Configuration File

--- a/config/cli.go
+++ b/config/cli.go
@@ -30,18 +30,20 @@ Where CHARTS_CONFIG is the location of the YAML file
 containing the Kubernetes Charts configuration.
 
 Arguments:
-  CHARTS_CONFIG           Charts configuration file
+  CHARTS_CONFIG                    Charts configuration file
 
 Options:
-  -h, --help              Show this screen
-  --version               Show version
-  -n NS, --namespace=NS   Set the .Release.Namespace chart variable, used by
-                          Charts during compilation
-  -a NAME, --name=NAME    Set the .Release.Name chart variable, used by charts
-                          during compilation
-  -o, --output PATH       Write output to a file, instead of STDOUT
-  --example-config        Print an example charts.yaml, including extended
-                          documentation on the tunables
+  -h, --help                       Show this screen
+  --version                        Show version
+  -n NS, --namespace=NS            Set the .Release.Namespace chart variable,
+                                   used by charts during compilation
+  -a NAME, --name=NAME             Set the .Release.Name chart variable, used by
+                                   charts during compilation
+  -o PATH, --output=PATH           Write output to a file, instead of STDOUT
+  -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
+                                   to the index before compiling charts config
+  --example-config                 Print an example charts.yaml, including
+                                   extended documentation on the tunables
 `
 
 // CLI returns the parsed command-line arguments

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/blendle/kubecrt/chartsconfig"
 	"github.com/blendle/kubecrt/config"
@@ -12,11 +13,23 @@ import (
 
 func main() {
 	cli := config.CLI()
-
 	opts, err := config.NewCLIOptions(cli)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "kubecrt arguments error: \n\n%s\n", err)
 		os.Exit(1)
+	}
+
+	if cli["--repo"] != nil {
+		for _, r := range strings.Split(cli["--repo"].(string), ",") {
+			p := strings.SplitN(r, "=", 2)
+			repo := strings.TrimSpace(string(p[0]))
+			url := strings.TrimSpace(string(p[1]))
+
+			if err = helm.AddRepository(repo, url); err != nil {
+				fmt.Fprintf(os.Stderr, "error adding repository: \n\n%s\n", err)
+				os.Exit(1)
+			}
+		}
 	}
 
 	cfg, err := readInput(opts.ChartsConfigurationPath)


### PR DESCRIPTION
You can now add repositories to Helms repository index without
defining them in the charts.yml.

This allows you, for example, to always add specific
repositories when executing `kubecrt` on your CI server:

    kubecrt --repo=myname=https://my-repo-address charts.yaml

```yaml
apiVersion: v1
charts:
- myname/chart1: {}
- myname/chart2: {}
```

the above now works, because the `myname` repository is already in the index, so you don't have to specify the `repo` key for both charts.