### PR TITLE
update epp dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,8 +28,8 @@
 [[projects]]
   name = "github.com/blendle/epp"
   packages = ["epp"]
-  revision = "de84831d04e7fd97fe42de190c47fd633162bfeb"
-  version = "v2.0.0-rc1"
+  revision = "f5da9002496df249035fa4823f7ddae7131658c5"
+  version = "v2.0.0-rc2"
 
 [[projects]]
   name = "github.com/docopt/docopt-go"
@@ -118,6 +118,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c78bd312deca6db84ee0fecde691efd7938c39d123d1fab1fbb3217c94e7ea8c"
+  inputs-digest = "15ab45d5a63b2b00f60533b804e5c92dee586fbddeeaae32488b596e9569444b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,4 +4,4 @@
 
 [[constraint]]
   name = "github.com/blendle/epp"
-  version = "2.0.0-rc1"
+  version = "2.0.0-rc2"


### PR DESCRIPTION
Closes https://github.com/blendle/kubecrt/issues/7. See https://github.com/blendle/epp/releases/tag/v2.0.0-rc2

---

- add `required` template helper

  This equals the templating function used in Helm.

  It provides a way to "require" a specific value to exist, or otherwise
  exit the execution of the template parsing.

  This can be useful when expecting an environment variable, and not
  accepting an empty string as value.

  Example:

  ```yaml
  password: {{ required "we really need this!" (env "SECRET_PASSWORD") }}
  ```

- add `include` template helper

  This equals the templating function used in Helm.

  It provides the same functionality as the Golang built-in "template"
  function, but returns the produced template string as the return value,
  allowing you to pipe the value to another template function.

  example:

  ```yaml
  {{ define "foobar" }}
  foo:
    bar: baz
  {{ end }}

  qux:
  {{ include "foobar" . | indent 2 }}

  # qux:
  #   foo:
  #     bar: baz
  ```