### PR TITLE
Auto update repositories when running kubecrt

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,14 +45,27 @@
 
 [[projects]]
   name = "github.com/gobwas/glob"
-  packages = [".","compiler","match","syntax","syntax/ast","syntax/lexer","util/runes","util/strings"]
+  packages = [
+    ".",
+    "compiler",
+    "match",
+    "syntax",
+    "syntax/ast",
+    "syntax/lexer",
+    "util/runes",
+    "util/strings"
+  ]
   revision = "bea32b9cd2d6f55753d94a28e959b13f0244797a"
   version = "v0.2.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes/any","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes/any",
+    "ptypes/timestamp"
+  ]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
@@ -82,7 +95,18 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["cast5","openpgp","openpgp/armor","openpgp/clearsign","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","pbkdf2","scrypt"]
+  packages = [
+    "cast5",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/clearsign",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "pbkdf2",
+    "scrypt"
+  ]
   revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
 
 [[projects]]
@@ -105,13 +129,33 @@
 
 [[projects]]
   name = "k8s.io/helm"
-  packages = ["cmd/helm/search","pkg/chartutil","pkg/downloader","pkg/engine","pkg/getter","pkg/helm/environment","pkg/helm/helmpath","pkg/ignore","pkg/plugin","pkg/proto/hapi/chart","pkg/proto/hapi/version","pkg/provenance","pkg/repo","pkg/resolver","pkg/timeconv","pkg/tlsutil","pkg/urlutil","pkg/version"]
-  revision = "8478fb4fc723885b155c924d1c8c410b7a9444e6"
-  version = "v2.7.2"
+  packages = [
+    "cmd/helm/search",
+    "pkg/chartutil",
+    "pkg/downloader",
+    "pkg/engine",
+    "pkg/getter",
+    "pkg/helm/environment",
+    "pkg/helm/helmpath",
+    "pkg/ignore",
+    "pkg/plugin",
+    "pkg/proto/hapi/chart",
+    "pkg/proto/hapi/version",
+    "pkg/provenance",
+    "pkg/repo",
+    "pkg/resolver",
+    "pkg/sympath",
+    "pkg/timeconv",
+    "pkg/tlsutil",
+    "pkg/urlutil",
+    "pkg/version"
+  ]
+  revision = "6af75a8fd72e2aa18a2b278cfe5c7a1c5feca7f2"
+  version = "v2.8.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b8600c13cc7208a1b5db60c7feba68f30c4ca87967a2e66c93c21217783e9957"
+  inputs-digest = "78715ab4ee50e2a102faecb7c285f45414938280da68c9f5cb3b0c362b723a48"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,6 @@
   version = "v1.0.1"
 
 [[projects]]
-  name = "github.com/blendle/epp"
-  packages = ["epp"]
-  revision = "4fffc632ad83289cd79c1ed346e73d46f9b39c90"
-  version = "v2.1.0"
-
-[[projects]]
   name = "github.com/docopt/docopt-go"
   packages = ["."]
   revision = "784ddc588536785e7299f7272f39101f7faccc3f"
@@ -156,6 +150,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "78715ab4ee50e2a102faecb7c285f45414938280da68c9f5cb3b0c362b723a48"
+  inputs-digest = "ff73565cd1dfcba890d7c70059b84ababc57754a4c63d7ecd3b8d85ac313b798"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "k8s.io/helm"
-  version = "v2.7.2"
+  version = "v2.8.1"
 
 [[constraint]]
   name = "github.com/blendle/epp"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,3 @@
 [[constraint]]
   name = "k8s.io/helm"
   version = "v2.8.1"
-
-[[constraint]]
-  name = "github.com/blendle/epp"
-  version = "2.0.0"

--- a/chartsconfig/parser.go
+++ b/chartsconfig/parser.go
@@ -2,11 +2,17 @@ package chartsconfig
 
 import (
 	"errors"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/blendle/epp/epp"
 	"github.com/blendle/kubecrt/chart"
 	yaml "gopkg.in/yaml.v2"
+	"k8s.io/helm/pkg/engine"
+	hchart "k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // ChartsConfiguration ...
@@ -18,14 +24,32 @@ type ChartsConfiguration struct {
 	ChartsList []*chart.Chart
 }
 
-// NewChartsConfiguration initialises a new ChartsConfiguration.
-func NewChartsConfiguration(input []byte) (*ChartsConfiguration, error) {
+// NewChartsConfiguration initializes a new ChartsConfiguration.
+func NewChartsConfiguration(input []byte, tpath string) (*ChartsConfiguration, error) {
 	m := &ChartsConfiguration{}
 
-	out, err := parseEpp(input)
+	renderer := engine.New()
+
+	funcs := template.FuncMap{
+		"env":       func(s string) string { return os.Getenv(s) },
+		"expandenv": func(s string) string { return os.ExpandEnv(s) },
+	}
+
+	for k, v := range funcs {
+		renderer.FuncMap[k] = v
+	}
+
+	t, err := stubChart(input, tpath)
 	if err != nil {
 		return nil, err
 	}
+
+	tpls, err := renderer.Render(t, map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	out := []byte(tpls["kubecrt/charts.yml"])
 
 	if err = yaml.Unmarshal(out, m); err != nil {
 		return nil, err
@@ -94,11 +118,35 @@ func (cc *ChartsConfiguration) Validate() error {
 	return nil
 }
 
-func parseEpp(input []byte) ([]byte, error) {
-	out, err := epp.Parse(input)
-	if err != nil {
-		return nil, err
+func stubChart(b []byte, partialPath string) (*hchart.Chart, error) {
+	tpls := []*hchart.Template{{Data: []byte(b), Name: "charts.yml"}}
+
+	if partialPath != "" {
+		err := filepath.Walk(partialPath, func(path string, f os.FileInfo, err error) error {
+			if info, err := os.Stat(path); err == nil && info.IsDir() {
+				return nil
+			}
+
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			tpls = append(tpls, &hchart.Template{Data: content, Name: strings.Replace(path, partialPath, "", 1)})
+			return nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return out, nil
+	chart := &hchart.Chart{
+		Metadata: &hchart.Metadata{
+			Name: "kubecrt",
+		},
+		Templates: tpls,
+	}
+
+	return chart, nil
 }

--- a/config/cli.go
+++ b/config/cli.go
@@ -42,6 +42,7 @@ Options:
   -o PATH, --output=PATH           Write output to a file, instead of STDOUT
   -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
                                    to the index before compiling charts config
+  -p DIR, --partials-dir=DIR       Path from which to load partial templates
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 `

--- a/config/cli.go
+++ b/config/cli.go
@@ -43,6 +43,7 @@ Options:
   -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
                                    to the index before compiling charts config
   -p DIR, --partials-dir=DIR       Path from which to load partial templates
+                                   [default: config/deploy/partials]
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 `

--- a/config/options.go
+++ b/config/options.go
@@ -2,6 +2,9 @@ package config
 
 import "errors"
 
+// DefaultPartialTemplatesPath is the default path used for partials.
+const DefaultPartialTemplatesPath = "config/deploy/partials"
+
 // CLIOptions contains all the options set through the CLI arguments
 type CLIOptions struct {
 	ChartsConfigurationPath    string

--- a/config/options.go
+++ b/config/options.go
@@ -5,6 +5,7 @@ import "errors"
 // CLIOptions contains all the options set through the CLI arguments
 type CLIOptions struct {
 	ChartsConfigurationPath    string
+	PartialTemplatesPath       string
 	ChartsConfigurationOptions *ChartsConfigurationOptions
 }
 
@@ -31,6 +32,10 @@ func NewCLIOptions(cli map[string]interface{}) (*CLIOptions, error) {
 			Name:      name,
 			Namespace: namespace,
 		},
+	}
+
+	if cli["--partials-dir"] != nil {
+		c.PartialTemplatesPath, _ = cli["--partials-dir"].(string)
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cc, err := chartsconfig.NewChartsConfiguration(cfg)
+	cc, err := chartsconfig.NewChartsConfiguration(cfg, opts.PartialTemplatesPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "charts config parsing error: \n\n%s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This should probably have some more smarts, to know when to update and
when not to, but at least this prevents the need to have the `helm`
binary installed locally, to be able to update repositories.

_still_ no tests, but verified locally