### PR TITLE
Add support for partials in charts.yml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,6 @@
   version = "v1.0.1"
 
 [[projects]]
-  name = "github.com/blendle/epp"
-  packages = ["epp"]
-  revision = "4fffc632ad83289cd79c1ed346e73d46f9b39c90"
-  version = "v2.1.0"
-
-[[projects]]
   name = "github.com/docopt/docopt-go"
   packages = ["."]
   revision = "784ddc588536785e7299f7272f39101f7faccc3f"
@@ -156,6 +150,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "78715ab4ee50e2a102faecb7c285f45414938280da68c9f5cb3b0c362b723a48"
+  inputs-digest = "ff73565cd1dfcba890d7c70059b84ababc57754a4c63d7ecd3b8d85ac313b798"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,3 @@
 [[constraint]]
   name = "k8s.io/helm"
   version = "v2.8.1"
-
-[[constraint]]
-  name = "github.com/blendle/epp"
-  version = "2.0.0"

--- a/chartsconfig/parser.go
+++ b/chartsconfig/parser.go
@@ -2,11 +2,17 @@ package chartsconfig
 
 import (
 	"errors"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/blendle/epp/epp"
 	"github.com/blendle/kubecrt/chart"
 	yaml "gopkg.in/yaml.v2"
+	"k8s.io/helm/pkg/engine"
+	hchart "k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // ChartsConfiguration ...
@@ -18,14 +24,32 @@ type ChartsConfiguration struct {
 	ChartsList []*chart.Chart
 }
 
-// NewChartsConfiguration initialises a new ChartsConfiguration.
-func NewChartsConfiguration(input []byte) (*ChartsConfiguration, error) {
+// NewChartsConfiguration initializes a new ChartsConfiguration.
+func NewChartsConfiguration(input []byte, tpath string) (*ChartsConfiguration, error) {
 	m := &ChartsConfiguration{}
 
-	out, err := parseEpp(input)
+	renderer := engine.New()
+
+	funcs := template.FuncMap{
+		"env":       func(s string) string { return os.Getenv(s) },
+		"expandenv": func(s string) string { return os.ExpandEnv(s) },
+	}
+
+	for k, v := range funcs {
+		renderer.FuncMap[k] = v
+	}
+
+	t, err := stubChart(input, tpath)
 	if err != nil {
 		return nil, err
 	}
+
+	tpls, err := renderer.Render(t, map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	out := []byte(tpls["kubecrt/charts.yml"])
 
 	if err = yaml.Unmarshal(out, m); err != nil {
 		return nil, err
@@ -94,11 +118,35 @@ func (cc *ChartsConfiguration) Validate() error {
 	return nil
 }
 
-func parseEpp(input []byte) ([]byte, error) {
-	out, err := epp.Parse(input)
-	if err != nil {
-		return nil, err
+func stubChart(b []byte, partialPath string) (*hchart.Chart, error) {
+	tpls := []*hchart.Template{{Data: []byte(b), Name: "charts.yml"}}
+
+	if partialPath != "" {
+		err := filepath.Walk(partialPath, func(path string, f os.FileInfo, err error) error {
+			if info, err := os.Stat(path); err == nil && info.IsDir() {
+				return nil
+			}
+
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			tpls = append(tpls, &hchart.Template{Data: content, Name: strings.Replace(path, partialPath, "", 1)})
+			return nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return out, nil
+	chart := &hchart.Chart{
+		Metadata: &hchart.Metadata{
+			Name: "kubecrt",
+		},
+		Templates: tpls,
+	}
+
+	return chart, nil
 }

--- a/config/cli.go
+++ b/config/cli.go
@@ -42,6 +42,7 @@ Options:
   -o PATH, --output=PATH           Write output to a file, instead of STDOUT
   -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
                                    to the index before compiling charts config
+  -p DIR, --partials-dir=DIR       Path from which to load partial templates
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 `

--- a/config/cli.go
+++ b/config/cli.go
@@ -43,6 +43,7 @@ Options:
   -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
                                    to the index before compiling charts config
   -p DIR, --partials-dir=DIR       Path from which to load partial templates
+                                   [default: config/deploy/partials]
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 `

--- a/config/options.go
+++ b/config/options.go
@@ -2,6 +2,9 @@ package config
 
 import "errors"
 
+// DefaultPartialTemplatesPath is the default path used for partials.
+const DefaultPartialTemplatesPath = "config/deploy/partials"
+
 // CLIOptions contains all the options set through the CLI arguments
 type CLIOptions struct {
 	ChartsConfigurationPath    string

--- a/config/options.go
+++ b/config/options.go
@@ -5,6 +5,7 @@ import "errors"
 // CLIOptions contains all the options set through the CLI arguments
 type CLIOptions struct {
 	ChartsConfigurationPath    string
+	PartialTemplatesPath       string
 	ChartsConfigurationOptions *ChartsConfigurationOptions
 }
 
@@ -31,6 +32,10 @@ func NewCLIOptions(cli map[string]interface{}) (*CLIOptions, error) {
 			Name:      name,
 			Namespace: namespace,
 		},
+	}
+
+	if cli["--partials-dir"] != nil {
+		c.PartialTemplatesPath, _ = cli["--partials-dir"].(string)
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cc, err := chartsconfig.NewChartsConfiguration(cfg)
+	cc, err := chartsconfig.NewChartsConfiguration(cfg, opts.PartialTemplatesPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "charts config parsing error: \n\n%s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
- Adds partials support for `charts.yml`
- Also removes the `epp` dependency
- _still_ no tests, will do this somewhere in the future, promised 🤞 

The rest of this description is the same as the updated README.md

---

## Partial Templates

You can optionally split your `charts.yml` file into multiple chunks, by using
_partial templates_. This works almost the same way as Helm's support for these
in charts. See the [Helm documentation][docs] for more details.

To use these partials, you have to set the `--partials-dir` flag when calling
`kubecrt`, pass it the path to your partials directory, and then use those
partials in your `charts.yml`.

Example:

**charts.yml**:

```yaml
apiVersion: v1
name: my-bundled-apps
namespace: apps
charts:
- stable/factorio:
    values:
      resources:
{{ include "factorio/resources" . | indent 8 }}
```

**partials/factorio/resources.yml**

```yaml
{{- define "factorio/resources" -}}
requests:
  memory: 1024Mi
  cpu: 750m
{{- end -}}
```

You can then run this as follows:

```
kubecrt --partials-dir ./partials charts.yml
```

And the result is a fully-parsed charts printed to stdout.

Some notes:

* you can use subfolders to organise your partials
* each named `define` has to be uniquely named, or risk being overwritten
* you can define multiple `define` blocks in a single file
* the files don't need to be yaml files, you can use any content you need

[docs]: https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/named_templates.md