### PR TITLE
Allow printing output in JSON formated style

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -150,6 +150,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ff73565cd1dfcba890d7c70059b84ababc57754a4c63d7ecd3b8d85ac313b798"
+  inputs-digest = "f304bb7f4f11d1f4c7f19999b95148d555f75ba09e2b996398ccc72f23758a48"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Options:
   -r NAME=URL, --repo=NAME=URL,... List of NAME=URL pairs of repositories to add
                                    to the index before compiling charts config
   -p DIR, --partials-dir=DIR       Path from which to load partial templates
+                                   [default: config/deploy/partials]
+  -j, --json                       Print resources formatted as JSON instead of
+                                   YAML. Each resource is printed on a single
+                                   line.
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 ```

--- a/config/cli.go
+++ b/config/cli.go
@@ -44,6 +44,9 @@ Options:
                                    to the index before compiling charts config
   -p DIR, --partials-dir=DIR       Path from which to load partial templates
                                    [default: config/deploy/partials]
+  -j, --json                       Print resources formatted as JSON instead of
+                                   YAML. Each resource is printed on a single
+                                   line.
   --example-config                 Print an example charts.yaml, including
                                    extended documentation on the tunables
 `

--- a/config/options.go
+++ b/config/options.go
@@ -10,6 +10,7 @@ type CLIOptions struct {
 	ChartsConfigurationPath    string
 	PartialTemplatesPath       string
 	ChartsConfigurationOptions *ChartsConfigurationOptions
+	OutputJSON                 bool
 }
 
 // ChartsConfigurationOptions contains the CLI options relevant for the charts
@@ -30,6 +31,7 @@ func NewCLIOptions(cli map[string]interface{}) (*CLIOptions, error) {
 	namespace, _ := cli["--namespace"].(string)
 
 	c := &CLIOptions{
+		OutputJSON:              cli["--json"].(bool),
 		ChartsConfigurationPath: path,
 		ChartsConfigurationOptions: &ChartsConfigurationOptions{
 			Name:      name,

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/blendle/kubecrt/chartsconfig"
 	"github.com/blendle/kubecrt/config"
 	"github.com/blendle/kubecrt/helm"
+	"github.com/ghodss/yaml"
 )
 
 func main() {
@@ -70,6 +72,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if opts.OutputJSON {
+		out, err = toJSON(out)
+		if err != nil {
+			fmt.Printf("error converting chart to JSON format: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
 	if cli["--output"] == nil {
 		fmt.Print(string(out))
 		return
@@ -87,4 +97,22 @@ func readInput(input string) ([]byte, error) {
 	}
 
 	return ioutil.ReadFile(input)
+}
+
+func toJSON(input []byte) ([]byte, error) {
+	var err error
+
+	bs := bytes.Split(input, []byte("---"))
+	for i := range bs {
+		if len(bs[i]) == 0 {
+			continue
+		}
+
+		bs[i], err = yaml.YAMLToJSON(bs[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return bytes.Join(bs, []byte("\n")), nil
 }


### PR DESCRIPTION
Kubernetes also accepts JSON-formatted resources. This allows you to do some filtering on the output using `jq` or similar tools.