### PR TITLE
Update stableRepositoryURL

### DIFF
--- a/helm/init.go
+++ b/helm/init.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	stableRepository    = "stable"
-	stableRepositoryURL = "https://kubernetes-charts.storage.googleapis.com"
+	stableRepositoryURL = "https://charts.helm.sh/stable"
 )
 
 // Init makes sure the Helm home path exists and the required subfolders.


### PR DESCRIPTION
The old URL was deprecated, so this replaces it.
This should fix some deployment errors.

https://stackoverflow.com/a/57970816